### PR TITLE
feat(dao:treasury): done the form changes for dao treasury step

### DIFF
--- a/src/features/create-dao/Steps/TreasuryForm.module.scss
+++ b/src/features/create-dao/Steps/TreasuryForm.module.scss
@@ -1,3 +1,17 @@
+@use '../../../../../zUI/src/styles/colors';
+
 .Footer {
 	margin-top: 5rem;
+}
+
+.InputExtraInfo {
+	text-align: right;
+	font-size: 0.75rem;
+	color: #{colors.$blue};
+	margin: 0.5rem 1.5rem 0 0;
+	display: block;
+
+	&.hasInputError {
+		margin-top: -0.6rem;
+	}
 }

--- a/src/features/create-dao/Steps/TreasuryForm.test.tsx
+++ b/src/features/create-dao/Steps/TreasuryForm.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
+import { TreasuryForm,TreasuryFormProps } from './';
+import { CreateDAOFormContext } from "../";
+
+let onSubmit = jest.fn();
+
+const DEFAULT_PROPS: TreasuryFormProps = {
+	onClose: jest.fn(),
+};
+
+const DEFAULT_PROVIDER_VALUES = {
+	stepId: 'treasury',
+	title: 'Create DAO',
+	details: {
+		mediaType: undefined,
+		previewUrl: '',
+		name: '',
+		znaAddress: '',
+		description: '',
+	},
+	governance: {
+		votingProcess: '',
+		votingPeriod: '',
+		votingSystem: '',
+		daoTokenAddress: '',
+		votingThreshold: '',
+	},
+	treasury: {
+		gnosisSafe: '',
+	},
+	onStepUpdate: jest.fn(),
+	onTitleUpdate: jest.fn(),
+	onDetailsSubmit: jest.fn(),
+	onGovernanceSubmit: jest.fn(),
+	onTreasurySubmit: onSubmit,
+	onLaunchSubmit: jest.fn(),
+};
+
+describe('<TreasuryForm />', () => {
+	beforeEach(() => jest.resetAllMocks());
+
+
+	test('should correctly validate required Gnosis Safe field', async () => {
+		render (
+			<ZUIProvider>
+				<CreateDAOFormContext.Provider value={DEFAULT_PROVIDER_VALUES}>
+					<TreasuryForm {...DEFAULT_PROPS} />
+				</CreateDAOFormContext.Provider>
+			</ZUIProvider>
+		);
+
+		fireEvent.blur(screen.getByPlaceholderText(/Enter gnosis safe address.../i));
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'Next',
+			}),
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText('The gnosis safe field is required.')).not.toBe(
+				null,
+			),
+		);
+	});
+
+	test('should fire onSubmit with expected params when next button clicked and field values are valid', async () => {
+		render (
+			<ZUIProvider>
+				<CreateDAOFormContext.Provider value={DEFAULT_PROVIDER_VALUES}>
+					<TreasuryForm {...DEFAULT_PROPS} />
+				</CreateDAOFormContext.Provider>
+			</ZUIProvider>
+		);
+
+		const user = userEvent.setup();
+
+		await user.type(
+			screen.getByPlaceholderText(/Enter gnosis safe address.../i),
+			'0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B',
+		);
+		
+		await user.click(screen.getByRole('button', { name: /Next/i }));
+
+		await waitFor(() =>
+			expect(onSubmit).toHaveBeenCalledWith({
+				gnosisSafe: '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B'
+			}),
+		);
+	});
+});

--- a/src/features/create-dao/Steps/TreasuryForm.tsx
+++ b/src/features/create-dao/Steps/TreasuryForm.tsx
@@ -1,24 +1,56 @@
 import { FC, useContext } from 'react';
 
+import * as Yup from 'yup';
 import { Form, Formik } from 'formik';
 
 import { Wizard } from '@zero-tech/zui/components';
+import { WrappedInput } from '../../ui/WrappedInput/WrappedInput';
 import { CreateDAOFormContext } from '../';
 
 import styles from './TreasuryForm.module.scss';
+import classNames from 'classnames/bind';
 
-interface TreasuryFormProps {
+const validationSchema = Yup.object().shape({
+	gnosisSafe: Yup.string().required('The gnosis safe field is required.'),
+});
+
+export interface TreasuryFormProps {
 	onClose: () => void;
 }
+
+const cx = classNames.bind(styles);
 
 export const TreasuryForm: FC<TreasuryFormProps> = ({ onClose }) => {
 	const { treasury, onTreasurySubmit } = useContext(CreateDAOFormContext);
 
 	return (
-		<Formik initialValues={treasury} onSubmit={onTreasurySubmit}>
-			{({ submitForm }) => (
+		<Formik
+			initialValues={treasury}
+			onSubmit={(values) => onTreasurySubmit(values)}
+			validationSchema={validationSchema}
+		>
+			{({ values, errors, touched, setFieldValue, submitForm }) => (
 				<Form>
-					<p>Enter treasury content here...</p>
+					<div>
+						<WrappedInput
+							label="What Ethereum address do you want all of the DAO’s funds to be held in?"
+							value={values.gnosisSafe}
+							placeholder="Enter gnosis safe address..."
+							info="This is a smart contract wallet that allows users to store Ether and ERC-20 tokens securely and interact with the decentralized web. It requires minimum number of people to approve a transaction before it can occur."
+							hasError={touched.gnosisSafe && !!errors.gnosisSafe}
+							helperText={touched.gnosisSafe && errors.gnosisSafe}
+							onChange={(value) => setFieldValue('gnosisSafe', value)}
+						/>
+						<a
+							className={cx(styles.InputExtraInfo, {
+								hasInputError: touched.gnosisSafe && !!errors.gnosisSafe,
+							})}
+							href="https://www.daomasters.xyz/tools/gnosis-safe#:~:text=Gnosis%20Safe%20is%20a%20smart,off%20on%20any%20fund%20transfers"
+							target="_blank"
+						>
+							Learn More
+						</a>
+					</div>
 					<Wizard.Buttons
 						className={styles.Footer}
 						isPrimaryButtonActive


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/rational-nomads/DAO-Launcher-Treasury-Step-51d9c67d5c24418aa392aba5965b3f7b)

-----

## 1. Pull request checklist

- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
 - Feature


## 3. What is the old behaviour?
Previously the treasury step for createDAO was empty.


## 4. What is the new behaviour?
Now it has a functioning treasury step where user can add gnosis safe that looks like the design.


## 5. Other information
